### PR TITLE
Add missing dependency tf2-ros-py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
     ros-${ROS_DISTRO}-lifecycle-msgs \
     ros-${ROS_DISTRO}-nav-msgs \
     ros-${ROS_DISTRO}-nav2-msgs \
+    ros-${ROS_DISTRO}-tf2-ros-py \
     ros-${ROS_DISTRO}-nav2-simple-commander \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hello, 

When I try to run the Docker container I'm getting the following error

```
   Building nav2-mcp-server @ file:///app
      Built nav2-mcp-server @ file:///app
Uninstalled 1 package in 4ms
Installed 1 package in 0.74ms
Traceback (most recent call last):
  File "/app/.venv/bin/nav2_mcp_server", line 4, in <module>
    from nav2_mcp_server.__main__ import main
  File "/app/src/nav2_mcp_server/__main__.py", line 15, in <module>
    from .server import main
  File "/app/src/nav2_mcp_server/server.py", line 30, in <module>
    from .tools import create_mcp_tools
  File "/app/src/nav2_mcp_server/tools.py", line 27, in <module>
    from .transforms import get_transform_manager
  File "/app/src/nav2_mcp_server/transforms.py", line 25, in <module>
    from tf2_ros import Buffer, TransformException, TransformListener
ModuleNotFoundError: No module named 'tf2_ros'
```
This PR fixes it