### PR TITLE
Fix/concurrency and tf spinner

### DIFF
--- a/src/nav2_mcp_server/transforms.py
+++ b/src/nav2_mcp_server/transforms.py
@@ -19,9 +19,12 @@ and robot pose operations.
 """
 
 import math
+import threading
+import time
 from typing import Any, Dict, Optional
 
 import rclpy
+from rclpy.executors import SingleThreadedExecutor
 from rclpy.node import Node
 from tf2_ros import Buffer, TransformException, TransformListener
 
@@ -39,13 +42,47 @@ class TransformManager:
         self._node: Optional[Node] = None
         self._tf_buffer: Optional[Buffer] = None
         self._tf_listener: Optional[TransformListener] = None
+        self._spin_executor: Optional[SingleThreadedExecutor] = None
+        self._spin_thread: Optional[threading.Thread] = None
+        self._spin_stop = threading.Event()
 
     def _ensure_tf_setup(self) -> None:
-        """Ensure TF components are initialized."""
+        """Ensure TF components are initialized.
+
+        Starts a daemon thread with a DEDICATED SingleThreadedExecutor
+        that continuously spins the TF node so the buffer stays
+        current with incoming /tf messages. Without continuous
+        spinning the buffer holds stale (minutes-old) data.
+
+        Why a dedicated executor: rclpy's default executor (used by
+        nav2 actions and other tools) raises `Executor is already
+        spinning` if two threads try to spin concurrently. A
+        SingleThreadedExecutor scoped to ONLY the TF node lets the
+        spinner run without conflicting with nav2's executor.
+        """
         if self._node is None:
             self._node = Node(self.config.logging.tf_node_name)
             self._tf_buffer = Buffer()
             self._tf_listener = TransformListener(self._tf_buffer, self._node)
+
+            # Dedicated executor for THIS node only — avoids conflict
+            # with the default executor that nav2 actions spin on.
+            self._spin_executor = SingleThreadedExecutor()
+            self._spin_executor.add_node(self._node)
+
+            # Background spinner — keeps /tf callbacks flowing into buffer
+            def _spin_loop() -> None:
+                while not self._spin_stop.is_set() and rclpy.ok():
+                    try:
+                        self._spin_executor.spin_once(timeout_sec=0.1)
+                    except Exception:
+                        # Executor or node shutting down; exit loop
+                        return
+
+            self._spin_thread = threading.Thread(
+                target=_spin_loop, daemon=True, name='tf_spinner'
+            )
+            self._spin_thread.start()
 
     def get_robot_pose(
         self, context_manager: MCPContextManager
@@ -80,14 +117,13 @@ class TransformManager:
             )
 
         try:
-            # Wait for transform to become available
+            # Wait for transform to become available. The background
+            # spinner thread (started in _ensure_tf_setup) keeps the
+            # buffer current; we just wait for the chain to be
+            # ready. ~5s max wall-time should be plenty.
             transform = None
-            while transform is None:
-                rclpy.spin_once(
-                    self._node,
-                    timeout_sec=self.config.navigation.default_tf_timeout
-                )
-
+            deadline_iters = 50
+            for _ in range(deadline_iters):
                 if self._tf_buffer.can_transform(
                     self.config.navigation.map_frame,
                     self.config.navigation.base_link_frame,
@@ -99,6 +135,9 @@ class TransformManager:
                         rclpy.time.Time(),  # get latest available transform
                     )
                     break
+                # Sleep briefly while the daemon spinner processes
+                # callbacks; don't spin here (would race with daemon).
+                time.sleep(0.1)
 
             if transform is None:
                 raise TransformError(

--- a/src/nav2_mcp_server/transforms.py
+++ b/src/nav2_mcp_server/transforms.py
@@ -69,12 +69,15 @@ class TransformManager:
             # with the default executor that nav2 actions spin on.
             self._spin_executor = SingleThreadedExecutor()
             self._spin_executor.add_node(self._node)
+            # Capture executor as a local so the closure carries a
+            # non-Optional reference (avoids union-attr at call site).
+            executor = self._spin_executor
 
             # Background spinner — keeps /tf callbacks flowing into buffer
             def _spin_loop() -> None:
                 while not self._spin_stop.is_set() and rclpy.ok():
                     try:
-                        self._spin_executor.spin_once(timeout_sec=0.1)
+                        executor.spin_once(timeout_sec=0.1)
                     except Exception:
                         # Executor or node shutting down; exit loop
                         return

--- a/src/nav2_mcp_server/utils.py
+++ b/src/nav2_mcp_server/utils.py
@@ -21,6 +21,7 @@ and common async/sync operations.
 import functools
 import json
 import logging
+import threading
 from typing import Any, Callable, Dict, Optional, TypeVar
 
 import anyio
@@ -30,6 +31,18 @@ from .config import get_config
 from .exceptions import Nav2MCPError, ROSError
 
 F = TypeVar('F', bound=Callable[..., Any])
+
+# Process-wide lock serializing all nav2-mcp tool entry points.
+#
+# Why: BasicNavigator (in navigation.py) and TransformManager (in
+# transforms.py) each create their own rclpy nodes and call spin
+# primitives. rclpy 2.x raises "Executor is already spinning" when two
+# threads try to spin overlapping. With FastMCP's HTTP/STDIO transports
+# both dispatching tool calls on a thread pool, two tool calls can race
+# on the executor and one fails. Serializing all tool calls behind this
+# lock costs throughput we don't have anyway (single-robot, sequential
+# operations) and eliminates the race.
+_ROS_LOCK = threading.Lock()
 
 
 class MCPContextManager:
@@ -157,17 +170,19 @@ def with_context_logging(func: F) -> F:
         # Add context manager to kwargs
         kwargs['context_manager'] = context_manager
 
-        try:
-            return func(*args, **kwargs)
-        except Nav2MCPError as e:
-            error_msg = f'Navigation error in {func.__name__}: {e.message}'
-            context_manager.error_sync(error_msg)
-            return json.dumps(e.to_dict(), indent=2)
-        except Exception as e:
-            error_msg = f'Unexpected error in {func.__name__}: {str(e)}'
-            context_manager.error_sync(error_msg)
-            ros_error = ROSError(error_msg, e)
-            return json.dumps(ros_error.to_dict(), indent=2)
+        # Serialize all rclpy access. See _ROS_LOCK comment above.
+        with _ROS_LOCK:
+            try:
+                return func(*args, **kwargs)
+            except Nav2MCPError as e:
+                error_msg = f'Navigation error in {func.__name__}: {e.message}'
+                context_manager.error_sync(error_msg)
+                return json.dumps(e.to_dict(), indent=2)
+            except Exception as e:
+                error_msg = f'Unexpected error in {func.__name__}: {str(e)}'
+                context_manager.error_sync(error_msg)
+                ros_error = ROSError(error_msg, e)
+                return json.dumps(ros_error.to_dict(), indent=2)
 
     return wrapper  # type: ignore[return-value]
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -26,6 +26,7 @@ class TestTransformManagerInitialization:
         assert tf_manager is not None
         assert tf_manager._node is None  # Node not created until needed
 
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
     @patch('nav2_mcp_server.transforms.rclpy.spin_once')
     @patch('nav2_mcp_server.transforms.TransformListener')
     @patch('nav2_mcp_server.transforms.Buffer')
@@ -37,11 +38,13 @@ class TestTransformManagerInitialization:
         mock_node_class: Mock,
         mock_buffer_class: Mock,
         mock_listener_class: Mock,
-        mock_spin: Mock
+        mock_spin: Mock,
+        mock_executor_class: Mock
     ) -> None:
         """Test TransformManager TF setup.
 
-        Verifies that TF2 buffer and listener are properly configured.
+        Verifies that TF2 buffer, listener, and dedicated spinner
+        executor are properly configured.
         """
         mock_node = Mock()
         mock_node_class.return_value = mock_node
@@ -57,11 +60,90 @@ class TestTransformManagerInitialization:
         mock_node_class.assert_called_once()
         mock_buffer_class.assert_called_once()
         mock_listener_class.assert_called_once()
+        # Dedicated executor for the TF node is created and the node
+        # is added to it (precondition for the background spinner).
+        mock_executor_class.assert_called_once()
+        mock_executor_class.return_value.add_node.assert_called_once_with(
+            mock_node
+        )
+
+    @patch('nav2_mcp_server.transforms.threading.Thread')
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
+    @patch('nav2_mcp_server.transforms.TransformListener')
+    @patch('nav2_mcp_server.transforms.Buffer')
+    @patch('nav2_mcp_server.transforms.Node')
+    def test_ensure_tf_setup_starts_daemon_spinner_thread(
+        self,
+        mock_node_class: Mock,
+        mock_buffer_class: Mock,
+        mock_listener_class: Mock,
+        mock_executor_class: Mock,
+        mock_thread_class: Mock
+    ) -> None:
+        """Test that _ensure_tf_setup starts a daemon spinner thread.
+
+        Verifies that the background TF spinner thread is created
+        with daemon=True (so it does not block process shutdown)
+        and is started exactly once.
+        """
+        mock_node_class.return_value = Mock()
+        mock_buffer_class.return_value = Mock()
+        mock_thread_instance = Mock()
+        mock_thread_class.return_value = mock_thread_instance
+
+        tf_manager = TransformManager()
+        tf_manager._ensure_tf_setup()
+
+        # Thread constructed exactly once with daemon=True.
+        mock_thread_class.assert_called_once()
+        kwargs = mock_thread_class.call_args.kwargs
+        assert kwargs.get('daemon') is True
+        # Spinner is named so it can be identified in stack traces.
+        assert kwargs.get('name') == 'tf_spinner'
+        # And the thread was actually started.
+        mock_thread_instance.start.assert_called_once()
+
+    @patch('nav2_mcp_server.transforms.threading.Thread')
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
+    @patch('nav2_mcp_server.transforms.TransformListener')
+    @patch('nav2_mcp_server.transforms.Buffer')
+    @patch('nav2_mcp_server.transforms.Node')
+    def test_ensure_tf_setup_is_idempotent(
+        self,
+        mock_node_class: Mock,
+        mock_buffer_class: Mock,
+        mock_listener_class: Mock,
+        mock_executor_class: Mock,
+        mock_thread_class: Mock
+    ) -> None:
+        """Test that _ensure_tf_setup is safe to call repeatedly.
+
+        Verifies that resources are created on the first call only.
+        Subsequent calls must not spawn additional nodes, executors,
+        or spinner threads (which would otherwise duplicate TF
+        callback processing).
+        """
+        mock_node_class.return_value = Mock()
+        mock_buffer_class.return_value = Mock()
+        mock_thread_class.return_value = Mock()
+
+        tf_manager = TransformManager()
+        tf_manager._ensure_tf_setup()
+        tf_manager._ensure_tf_setup()
+        tf_manager._ensure_tf_setup()
+
+        # Resources created exactly once across multiple calls.
+        mock_node_class.assert_called_once()
+        mock_buffer_class.assert_called_once()
+        mock_listener_class.assert_called_once()
+        mock_executor_class.assert_called_once()
+        mock_thread_class.assert_called_once()
 
 
 class TestGetRobotPose:
     """Tests for robot pose retrieval functionality."""
 
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
     @patch('nav2_mcp_server.transforms.rclpy.spin_once')
     @patch('nav2_mcp_server.transforms.TransformListener')
     @patch('nav2_mcp_server.transforms.Buffer')
@@ -71,7 +153,8 @@ class TestGetRobotPose:
         mock_node_class: Mock,
         mock_buffer_class: Mock,
         mock_listener_class: Mock,
-        mock_spin: Mock
+        mock_spin: Mock,
+        mock_executor_class: Mock
     ) -> None:
         """Test successful robot pose retrieval.
 
@@ -108,6 +191,7 @@ class TestGetRobotPose:
         assert result['position']['x'] == 1.0
         assert result['position']['y'] == 2.0
 
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
     @patch('nav2_mcp_server.transforms.rclpy.spin_once')
     @patch('nav2_mcp_server.transforms.TransformListener')
     @patch('nav2_mcp_server.transforms.Buffer')
@@ -117,7 +201,8 @@ class TestGetRobotPose:
         mock_node_class: Mock,
         mock_buffer_class: Mock,
         mock_listener_class: Mock,
-        mock_spin: Mock
+        mock_spin: Mock,
+        mock_executor_class: Mock
     ) -> None:
         """Test robot pose retrieval with transform failure.
 
@@ -144,6 +229,7 @@ class TestGetRobotPose:
         with pytest.raises(TransformError):
             tf_manager.get_robot_pose(context_manager)
 
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
     @patch('nav2_mcp_server.transforms.rclpy.spin_once')
     @patch('nav2_mcp_server.transforms.TransformListener')
     @patch('nav2_mcp_server.transforms.Buffer')
@@ -153,7 +239,8 @@ class TestGetRobotPose:
         mock_node_class: Mock,
         mock_buffer_class: Mock,
         mock_listener_class: Mock,
-        mock_spin: Mock
+        mock_spin: Mock,
+        mock_executor_class: Mock
     ) -> None:
         """Test robot pose retrieval works with config frames.
 
@@ -189,6 +276,67 @@ class TestGetRobotPose:
         assert result['position']['x'] == 3.0
         assert result['position']['y'] == 4.0
         assert result['position']['z'] == 0.5
+
+    @patch('nav2_mcp_server.transforms.time.sleep')
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
+    @patch('nav2_mcp_server.transforms.TransformListener')
+    @patch('nav2_mcp_server.transforms.Buffer')
+    @patch('nav2_mcp_server.transforms.Node')
+    def test_get_robot_pose_waits_for_transform_availability(
+        self,
+        mock_node_class: Mock,
+        mock_buffer_class: Mock,
+        mock_listener_class: Mock,
+        mock_executor_class: Mock,
+        mock_sleep: Mock
+    ) -> None:
+        """Test that get_robot_pose polls until the transform is ready.
+
+        The background spinner keeps the buffer current; the public
+        method must poll can_transform and only call lookup_transform
+        once the chain is available. Verifies the poll-then-lookup
+        pattern by returning False for the first few polls and True
+        thereafter.
+        """
+        mock_node_class.return_value = Mock()
+        mock_buffer_instance = Mock()
+        mock_buffer_class.return_value = mock_buffer_instance
+
+        # Build a valid transform that will be returned on lookup.
+        mock_transform = Mock()
+        mock_transform.transform.translation.x = 1.0
+        mock_transform.transform.translation.y = 2.0
+        mock_transform.transform.translation.z = 0.0
+        mock_transform.transform.rotation.x = 0.0
+        mock_transform.transform.rotation.y = 0.0
+        mock_transform.transform.rotation.z = 0.0
+        mock_transform.transform.rotation.w = 1.0
+        mock_transform.header.stamp.sec = 0
+        mock_transform.header.stamp.nanosec = 0
+
+        # Transform unavailable on first three polls, available on
+        # the fourth. The method should sleep between polls and then
+        # call lookup_transform exactly once.
+        mock_buffer_instance.can_transform.side_effect = [
+            False, False, False, True
+        ]
+        mock_buffer_instance.lookup_transform.return_value = mock_transform
+
+        tf_manager = TransformManager()
+        context_manager = MCPContextManager()
+
+        result = tf_manager.get_robot_pose(context_manager)
+
+        # Polled four times in total (three misses, one hit).
+        assert mock_buffer_instance.can_transform.call_count == 4
+        # Lookup happened exactly once, after the transform became
+        # available — not on every iteration of the poll loop.
+        mock_buffer_instance.lookup_transform.assert_called_once()
+        # Slept between failed polls (at least three times).
+        assert mock_sleep.call_count >= 3
+        # Result reflects the transform that became available.
+        assert result['position']['x'] == 1.0
+        assert result['position']['y'] == 2.0
 
 
 class TestPoseExtraction:
@@ -388,6 +536,7 @@ class TestTransformManagerGlobal:
 class TestTransformManagerErrorHandling:
     """Tests for TransformManager error handling."""
 
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
     @patch('nav2_mcp_server.transforms.rclpy.spin_once')
     @patch('nav2_mcp_server.transforms.TransformListener')
     @patch('nav2_mcp_server.transforms.Buffer')
@@ -397,7 +546,8 @@ class TestTransformManagerErrorHandling:
         mock_node_class: Mock,
         mock_buffer_class: Mock,
         mock_listener_class: Mock,
-        mock_spin: Mock
+        mock_spin: Mock,
+        mock_executor_class: Mock
     ) -> None:
         """Test robot pose retrieval with timeout error.
 
@@ -436,6 +586,7 @@ class TestTransformManagerErrorHandling:
         assert tf_manager is not None
         assert tf_manager._node is None  # Not initialized yet
 
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
     @patch('nav2_mcp_server.transforms.rclpy.spin_once')
     @patch('nav2_mcp_server.transforms.TransformListener')
     @patch('nav2_mcp_server.transforms.Buffer')
@@ -445,7 +596,8 @@ class TestTransformManagerErrorHandling:
         mock_node_class: Mock,
         mock_buffer_class: Mock,
         mock_listener_class: Mock,
-        mock_spin: Mock
+        mock_spin: Mock,
+        mock_executor_class: Mock
     ) -> None:
         """Test robot pose retrieval when buffer is not initialized.
 
@@ -466,6 +618,8 @@ class TestTransformManagerErrorHandling:
         with pytest.raises(TransformError, match='TF buffer not initialized'):
             tf_manager.get_robot_pose(context_manager)
 
+    @patch('nav2_mcp_server.transforms.time.sleep')
+    @patch('nav2_mcp_server.transforms.SingleThreadedExecutor')
     @patch('nav2_mcp_server.transforms.rclpy.spin_once')
     @patch('nav2_mcp_server.transforms.TransformListener')
     @patch('nav2_mcp_server.transforms.Buffer')
@@ -475,14 +629,15 @@ class TestTransformManagerErrorHandling:
         mock_node_class: Mock,
         mock_buffer_class: Mock,
         mock_listener_class: Mock,
-        mock_spin: Mock
+        mock_spin: Mock,
+        mock_executor_class: Mock,
+        mock_sleep: Mock
     ) -> None:
         """Test robot pose when transform never becomes available.
 
-        Verifies timeout handling when transform is not available.
+        Verifies that the wait-until-available polling loop exits
+        and raises TransformError when can_transform never succeeds.
         """
-        from typing import Any
-
         from nav2_mcp_server.exceptions import TransformError
 
         mock_node = Mock()
@@ -490,26 +645,17 @@ class TestTransformManagerErrorHandling:
         mock_buffer_instance = Mock()
         mock_buffer_class.return_value = mock_buffer_instance
 
-        # Mock transform never available
+        # Transform never becomes available throughout the polling
+        # window. The 0.1 s sleep between polls is mocked out so the
+        # loop completes its 50 iterations quickly.
         mock_buffer_instance.can_transform.return_value = False
 
         tf_manager = TransformManager()
         context_manager = MCPContextManager()
 
-        # Limit spin_once calls to avoid infinite loop
-        call_count = [0]
-
-        def spin_side_effect(*args: Any, **kwargs: Any) -> None:
-            call_count[0] += 1
-            if call_count[0] > 5:
-                # Force exception after a few tries
-                raise TransformError(
-                    'Could not get transform after waiting',
-                    0,
-                    {}
-                )
-
-        mock_spin.side_effect = spin_side_effect
-
-        with pytest.raises(TransformError):
+        with pytest.raises(TransformError, match='after waiting'):
             tf_manager.get_robot_pose(context_manager)
+
+        # Polling loop ran the full budget and slept between attempts.
+        assert mock_sleep.called
+        assert mock_buffer_instance.can_transform.call_count >= 10


### PR DESCRIPTION
## Summary

Two `rclpy` executor concurrency fixes that surface together when MCP tools are dispatched in parallel alongside an active nav2 action and the TF buffer is being polled.

## Problem

**Tool-call races on the default executor.** Concurrent MCP tools share `rclpy`'s default executor. Both threads spin it, and the executor swap occasionally leaves a goal-monitoring result in a transient state. Errors raised inside the action wait-loop are then returned to the caller as JSON success-strings instead of being raised.

**TF spinner clashes with nav2 actions.** `get_robot_pose` previously spun the TF node on-demand inside the calling thread. With a nav2 action active at the same time, both spinners targeted the default executor: one raised `RuntimeError: Executor is already spinning`, the other proceeded with stale `/tf` data, and the robot's reported pose lagged or never updated.

## Changes

### `fix: serialize tool calls behind a process-wide lock`

A single `threading.Lock` acquired inside the shared sync-call wrapper forces MCP tool calls through one at a time at the `rclpy` boundary. Trades parallelism for determinism, which is the right balance for a server fronting a single robot.

### `fix: dedicated executor for TF spinner to avoid clash with nav2 actions`

- Add a daemon thread that continuously spins the TF node so `/tf` callbacks are processed as they arrive into the buffer.
- Use a dedicated `SingleThreadedExecutor` scoped to only the TF node, avoiding contention with the default executor that nav2 action clients spin.
- Replace the on-demand while-spin loop in `get_robot_pose` with a wait-until-available pattern (5 s max). The buffer is already fresh by the time we look it up.

## Notes

Both issues surfaced while running the server in `jazzy` against a real navigation stack with an LLM-driven client calling tools in parallel. Open to splitting the lock into a finer-grained primitive if you prefer; the process-wide lock was the smallest correct fix.
