### PR TITLE
Feat/approach and heading

### DIFF
--- a/src/nav2_mcp_server/navigation.py
+++ b/src/nav2_mcp_server/navigation.py
@@ -398,6 +398,79 @@ class NavigationManager:
             raise create_navigation_error_from_result(
                 result, 'Drive on heading operation')
 
+    def approach_target(
+        self,
+        target_x_base: float,
+        target_y_base: float,
+        standoff_m: float,
+        speed: float,
+        context_manager: MCPContextManager,
+    ) -> str:
+        """Drive the robot to ``standoff_m`` from a target given in base_footprint.
+
+        Given a target's xy in base_footprint frame, spin to face the target
+        if the bearing is significant, then drive forward by
+        ``dist - standoff_m`` along the now-aligned heading using
+        ``drive_on_heading``. Returns immediately if the target is already
+        within ``standoff_m + 0.10m``.
+
+        The caller is responsible for any post-approach perception check.
+        This method does not re-verify the target position after driving.
+
+        Parameters
+        ----------
+        target_x_base : float
+            Target x in the robot's base_footprint frame (forward = +x).
+        target_y_base : float
+            Target y in the robot's base_footprint frame (left = +y).
+        standoff_m : float
+            Desired distance from the target after the approach.
+        speed : float
+            Forward drive speed in m/s.
+        context_manager : MCPContextManager
+            Context manager for logging.
+
+        Returns
+        -------
+        str
+            Summary of what was executed.
+        """
+        target_dist = math.hypot(target_x_base, target_y_base)
+        bearing = math.atan2(target_y_base, target_x_base)
+
+        self.navigator.get_logger().info(
+            f'approach_target: base=({target_x_base:.2f},{target_y_base:.2f}) '
+            f'dist={target_dist:.2f}m bearing={math.degrees(bearing):.1f}deg '
+            f'standoff={standoff_m:.2f}m'
+        )
+        context_manager.info_sync(
+            f'approach_target: dist={target_dist:.2f}m -> standoff={standoff_m:.2f}m'
+        )
+
+        # Already within standoff (with 10cm tolerance). Don't drive — that
+        # would back away from a target the manipulator can already reach.
+        if target_dist <= standoff_m + 0.10:
+            return (
+                f'Already at {target_dist:.2f}m (<= standoff '
+                f'{standoff_m:.2f}m + 0.10m); no approach needed'
+            )
+
+        # Spin to face the target if the bearing is significant. ~8 deg
+        # threshold avoids burning a spin call on near-aligned targets.
+        if abs(bearing) > math.radians(8):
+            self.spin_robot(bearing, context_manager)
+
+        # Drive forward by (dist - standoff) along the now-aligned heading.
+        # Range validation, action-server check, and result handling all
+        # live in drive_on_heading.
+        drive_dist = max(target_dist - standoff_m, 0.20)
+        self.drive_on_heading(drive_dist, speed, context_manager)
+
+        return (
+            f'Approached target: spun {math.degrees(bearing):.1f}deg, '
+            f'drove {drive_dist:.2f}m -> ~{standoff_m:.2f}m standoff'
+        )
+
     def clear_costmaps(
         self, costmap_type: str, context_manager: MCPContextManager
     ) -> str:

--- a/src/nav2_mcp_server/navigation.py
+++ b/src/nav2_mcp_server/navigation.py
@@ -20,7 +20,7 @@ operations including pose navigation, waypoint following, and robot control.
 
 import json
 import math
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from geometry_msgs.msg import PoseStamped
 from nav2_simple_commander.robot_navigator import BasicNavigator, TaskResult
@@ -799,7 +799,7 @@ class NavigationManager:
             self._navigator = None
 
     def _ensure_action_server(
-        self, client, action_name: str, timeout: float = 5.0
+        self, client: Any, action_name: str, timeout: float = 5.0
     ) -> None:
         """Fail fast if a BasicNavigator action server is not advertised.
 

--- a/src/nav2_mcp_server/navigation.py
+++ b/src/nav2_mcp_server/navigation.py
@@ -334,6 +334,70 @@ class NavigationManager:
             raise create_navigation_error_from_result(
                 result, 'Backup operation')
 
+    def drive_on_heading(
+        self, distance: float, speed: float, context_manager: MCPContextManager
+    ) -> str:
+        """Drive robot forward by specified distance on its current heading.
+
+        Parameters
+        ----------
+        distance : float
+            Distance to drive forward in meters (positive value).
+        speed : float
+            Forward speed in m/s.
+        context_manager : MCPContextManager
+            Context manager for logging.
+
+        Returns
+        -------
+        str
+            Success message with distance.
+
+        Raises
+        ------
+        NavigationError
+            If drive operation fails.
+        ValueError
+            If distance or speed parameters are invalid.
+        """
+        # Reuse backup limits (physical motion limits, direction-agnostic)
+        validate_numeric_range(
+            distance,
+            self.config.navigation.min_backup_distance,
+            self.config.navigation.max_backup_distance,
+            'distance'
+        )
+        validate_numeric_range(
+            speed,
+            self.config.navigation.min_backup_speed,
+            self.config.navigation.max_backup_speed,
+            'speed'
+        )
+
+        time_allowance = int(distance / speed + 5)
+
+        self.navigator.get_logger().info(
+            f'Driving robot on heading: {distance:.2f}m at {speed:.2f}m/s'
+        )
+        context_manager.info_sync(
+            f'Starting drive on heading: {distance:.2f}m at {speed:.2f}m/s'
+        )
+
+        self._ensure_action_server(
+            self.navigator.drive_on_heading_client, '/drive_on_heading'
+        )
+        self.navigator.driveOnHeading(distance, speed, time_allowance)
+        self._monitor_navigation_progress(
+            context_manager, 'drive on heading operation'
+        )
+
+        result = self.navigator.getResult()
+        if result == TaskResult.SUCCEEDED:
+            return f'Successfully drove {distance:.2f} meters on heading'
+        else:
+            raise create_navigation_error_from_result(
+                result, 'Drive on heading operation')
+
     def clear_costmaps(
         self, costmap_type: str, context_manager: MCPContextManager
     ) -> str:

--- a/src/nav2_mcp_server/navigation.py
+++ b/src/nav2_mcp_server/navigation.py
@@ -182,6 +182,9 @@ class NavigationManager:
             f'Navigating to pose: x={x:.2f}, y={y:.2f}, yaw={yaw:.2f}'
         )
 
+        self._ensure_action_server(
+            self.navigator.nav_to_pose_client, '/navigate_to_pose'
+        )
         self.navigator.goToPose(goal_pose)
         self._monitor_navigation_progress(context_manager, 'pose navigation')
 
@@ -222,6 +225,9 @@ class NavigationManager:
             f'Starting waypoint following with {len(poses)} points'
         )
 
+        self._ensure_action_server(
+            self.navigator.follow_waypoints_client, '/follow_waypoints'
+        )
         self.navigator.followWaypoints(poses)
         self._monitor_waypoint_progress(context_manager)
 
@@ -260,6 +266,7 @@ class NavigationManager:
         context_manager.info_sync(
             f'Starting spin operation: {angle:.2f} radians')
 
+        self._ensure_action_server(self.navigator.spin_client, '/spin')
         self.navigator.spin(angle)
         self._monitor_navigation_progress(context_manager, 'spin operation')
 
@@ -316,6 +323,7 @@ class NavigationManager:
             f'Starting backup: {distance:.2f}m at {speed:.2f}m/s'
         )
 
+        self._ensure_action_server(self.navigator.backup_client, '/backup')
         self.navigator.backup(distance, speed)
         self._monitor_navigation_progress(context_manager, 'backup operation')
 
@@ -575,6 +583,9 @@ class NavigationManager:
                     f' {dock_pose.pose.position.y:.2f})'
                 )
 
+            self._ensure_action_server(
+                self.navigator.docking_client, '/dock_robot'
+            )
             self.navigator.dockRobotByPose(dock_pose, dock_type, nav_to_dock)
             dock_description = (
                 f'pose ({dock_pose.pose.position.x:.2f},\n'
@@ -588,6 +599,9 @@ class NavigationManager:
                 context_manager.info_sync(
                     f'Starting dock operation at dock ID: {dock_id}')
 
+            self._ensure_action_server(
+                self.navigator.docking_client, '/dock_robot'
+            )
             self.navigator.dockRobotByID(dock_id, nav_to_dock)
             dock_description = f'dock ID: {dock_id}'
 
@@ -627,6 +641,9 @@ class NavigationManager:
         if context_manager:
             context_manager.info_sync('Starting undock operation')
 
+        self._ensure_action_server(
+            self.navigator.undocking_client, '/undock_robot'
+        )
         self.navigator.undockRobot(dock_type)
         self._monitor_navigation_progress(context_manager, 'undock operation')
 
@@ -643,6 +660,33 @@ class NavigationManager:
         if self._navigator:
             self._navigator.destroy_node()
             self._navigator = None
+
+    def _ensure_action_server(
+        self, client, action_name: str, timeout: float = 5.0
+    ) -> None:
+        """Fail fast if a BasicNavigator action server is not advertised.
+
+        BasicNavigator's goToPose / spin / backup / driveOnHeading / etc.
+        internally call ``wait_for_server()`` with NO TIMEOUT — if the
+        target action server (e.g. /navigate_to_pose, /spin) is missing
+        because nav2 wasn't launched fully or its lifecycle never
+        activated, those calls hang indefinitely. The MCP tool then
+        appears to "time out" client-side after 90-180s with no
+        actionable error.
+
+        This helper runs ``wait_for_server(timeout_sec=timeout)`` BEFORE
+        the goal-sending call. If the server isn't up within the budget,
+        we raise a NAV2_NOT_ACTIVE error immediately so the caller sees
+        a fast, actionable failure ("nav2 not active") rather than a
+        long hang.
+        """
+        if not client.wait_for_server(timeout_sec=timeout):
+            raise NavigationError(
+                f'Action server for {action_name} not available after '
+                f'{timeout}s — is nav2 fully launched and lifecycle-active?',
+                NavigationErrorCode.NAV2_NOT_ACTIVE,
+                {'action': action_name, 'wait_timeout_sec': timeout},
+            )
 
     def _monitor_navigation_progress(
         self, context_manager: MCPContextManager, operation_name: str

--- a/src/nav2_mcp_server/tools.py
+++ b/src/nav2_mcp_server/tools.py
@@ -208,6 +208,57 @@ def create_mcp_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool(
+        name='approach_target',
+        description="""Drive the robot to a desired standoff distance from a
+        target whose xy is given in base_footprint frame. Spins to face the
+        target if the bearing is significant, then drives forward by
+        (target_distance - standoff). Returns immediately if the target is
+        already within standoff + 10 cm.
+
+        The caller supplies the target xy (e.g. from a perception
+        pipeline's object centroid in base_footprint frame). This tool
+        does NOT re-verify after the approach.
+
+        Example usage:
+        - approach a target at (0.95, -0.10) in base frame to 0.85 m standoff
+        - drive in to 0.45 m for surface placement
+        """,
+        tags={'approach', 'standoff', 'creep', 'drive', 'target'},
+        annotations={
+            'title': 'Approach Target At Standoff',
+            'readOnlyHint': False,
+            'openWorldHint': False
+        },
+    )
+    async def approach_target(
+        target_x_base: Annotated[
+            float,
+            'Target x in base_footprint frame (forward = +x)'
+        ],
+        target_y_base: Annotated[
+            float,
+            'Target y in base_footprint frame (left = +y)'
+        ],
+        standoff_m: Annotated[
+            float,
+            'Desired distance from target after approach (m); '
+            'choose based on your manipulator reach'
+        ],
+        speed: Annotated[
+            Optional[float],
+            'Forward drive speed in m/s (typically 0.1-0.5)'
+        ] = None,
+        ctx: Annotated[Optional[Context], 'MCP context for logging'] = None,
+    ) -> str:
+        """Approach a base-frame target to a desired standoff distance."""
+        if speed is None:
+            speed = config.navigation.default_backup_speed
+        return await anyio.to_thread.run_sync(
+            _approach_target_sync,
+            target_x_base, target_y_base, standoff_m, speed, ctx,
+        )
+
+    @mcp.tool(
         name='dock_robot',
         description="""Dock the robot to a charging station or dock.
 
@@ -525,6 +576,23 @@ def _drive_on_heading_sync(
     """Drive robot on heading synchronously."""
     nav_manager = get_navigation_manager()
     return nav_manager.drive_on_heading(distance, speed, context_manager)
+
+
+@with_context_logging
+# @with_nav2_active_check
+def _approach_target_sync(
+    target_x_base: float,
+    target_y_base: float,
+    standoff_m: float,
+    speed: float,
+    ctx: Optional[Context] = None,
+    context_manager: Optional[MCPContextManager] = None,
+) -> str:
+    """Approach a base-frame target synchronously."""
+    nav_manager = get_navigation_manager()
+    return nav_manager.approach_target(
+        target_x_base, target_y_base, standoff_m, speed, context_manager,
+    )
 
 
 @with_context_logging

--- a/src/nav2_mcp_server/tools.py
+++ b/src/nav2_mcp_server/tools.py
@@ -174,6 +174,40 @@ def create_mcp_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool(
+        name='drive_on_heading',
+        description="""Move the robot forward by a specified distance along
+        its current heading.
+
+        Example usage:
+        - drive forward 0.5 meters at 0.2 m/s
+        - move robot 1 meter on heading
+        - drive on heading 0.3 meters slowly
+        """,
+        tags={'drive', 'forward', 'on heading', 'move forward'},
+        annotations={
+            'title': 'Drive On Heading',
+            'readOnlyHint': False,
+            'openWorldHint': False
+        },
+    )
+    async def drive_on_heading(
+        distance: Annotated[
+            float, 'Distance to drive forward in meters (positive value)'
+        ],
+        speed: Annotated[
+            Optional[float],
+            'Forward speed in m/s (typically 0.1-0.5)'
+        ] = None,
+        ctx: Annotated[Optional[Context], 'MCP context for logging'] = None,
+    ) -> str:
+        """Drive the robot forward in a straight line along current heading."""
+        if speed is None:
+            speed = config.navigation.default_backup_speed
+        return await anyio.to_thread.run_sync(
+            _drive_on_heading_sync, distance, speed, ctx
+        )
+
+    @mcp.tool(
         name='dock_robot',
         description="""Dock the robot to a charging station or dock.
 
@@ -479,6 +513,18 @@ def _backup_robot_sync(
     """Back up robot synchronously."""
     nav_manager = get_navigation_manager()
     return nav_manager.backup_robot(distance, speed, context_manager)
+
+
+@with_context_logging
+# @with_nav2_active_check
+def _drive_on_heading_sync(
+    distance: float, speed: float,
+    ctx: Optional[Context] = None,
+    context_manager: Optional[MCPContextManager] = None
+) -> str:
+    """Drive robot on heading synchronously."""
+    nav_manager = get_navigation_manager()
+    return nav_manager.drive_on_heading(distance, speed, context_manager)
 
 
 @with_context_logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,12 @@ def mock_navigation_manager() -> Mock:
     mock_nav_manager.backup_robot.return_value = (
         'Backup operation started successfully'
     )
+    mock_nav_manager.drive_on_heading.return_value = (
+        'Drive on heading operation started successfully'
+    )
+    mock_nav_manager.approach_target.return_value = (
+        'Approach target operation completed successfully'
+    )
     mock_nav_manager.dock_robot.return_value = (
         'Docking operation started successfully'
     )

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1287,3 +1287,211 @@ class TestGetPathWithoutContextManager:
         assert call_args is not None
         # Third argument (index 2) should be planner_id
         assert call_args[0][2] == 'NavFn'
+
+
+class TestDriveOnHeading:
+    """Tests for drive_on_heading primitive."""
+
+    @patch('nav2_mcp_server.navigation.BasicNavigator')
+    def test_drive_on_heading_success(self, mock_navigator_class: Mock) -> None:
+        """Test successful forward drive on heading.
+
+        Verifies that the BasicNavigator.driveOnHeading action is
+        invoked with the requested distance and speed and that the
+        success result is returned.
+        """
+        mock_navigator = Mock()
+        mock_navigator.getResult.return_value = TaskResult.SUCCEEDED
+        mock_navigator_class.return_value = mock_navigator
+
+        nav_manager = NavigationManager()
+        context_manager = MCPContextManager()
+
+        result = nav_manager.drive_on_heading(0.5, 0.2, context_manager)
+
+        assert 'success' in result.lower()
+        mock_navigator.driveOnHeading.assert_called_once()
+        # First two positional args are distance and speed.
+        call_args = mock_navigator.driveOnHeading.call_args
+        assert call_args[0][0] == 0.5
+        assert call_args[0][1] == 0.2
+
+    @patch('nav2_mcp_server.navigation.BasicNavigator')
+    def test_drive_on_heading_failure(self, mock_navigator_class: Mock) -> None:
+        """Test drive_on_heading propagates BasicNavigator failure.
+
+        Verifies that a FAILED task result is converted into a
+        NavigationError rather than silently returning success.
+        """
+        mock_navigator = Mock()
+        mock_navigator.getResult.return_value = TaskResult.FAILED
+        mock_navigator_class.return_value = mock_navigator
+
+        nav_manager = NavigationManager()
+        context_manager = MCPContextManager()
+
+        with pytest.raises(NavigationError):
+            nav_manager.drive_on_heading(0.5, 0.2, context_manager)
+
+    @patch('nav2_mcp_server.navigation.BasicNavigator')
+    def test_drive_on_heading_validates_speed(
+        self, mock_navigator_class: Mock
+    ) -> None:
+        """Test that out-of-range speed is rejected before motion.
+
+        Verifies that drive_on_heading rejects a zero (or otherwise
+        invalid) speed via validate_numeric_range, so the action
+        server is never contacted with bogus parameters.
+        """
+        mock_navigator = Mock()
+        mock_navigator_class.return_value = mock_navigator
+
+        nav_manager = NavigationManager()
+        context_manager = MCPContextManager()
+
+        with pytest.raises(ValueError):
+            nav_manager.drive_on_heading(0.5, 0.0, context_manager)
+        mock_navigator.driveOnHeading.assert_not_called()
+
+
+class TestApproachTarget:
+    """Tests for approach_target spin-and-drive primitive."""
+
+    @patch('nav2_mcp_server.navigation.BasicNavigator')
+    def test_approach_target_skips_when_already_within_standoff(
+        self, mock_navigator_class: Mock
+    ) -> None:
+        """Test that approach_target returns immediately when close.
+
+        A target at 0.50 m with a 0.85 m standoff is already within
+        ``standoff + 0.10`` so the robot must not drive backwards.
+        No spin or drive action should be issued.
+        """
+        mock_navigator = Mock()
+        mock_navigator_class.return_value = mock_navigator
+
+        nav_manager = NavigationManager()
+        context_manager = MCPContextManager()
+
+        result = nav_manager.approach_target(
+            target_x_base=0.50,
+            target_y_base=0.0,
+            standoff_m=0.85,
+            speed=0.2,
+            context_manager=context_manager,
+        )
+
+        assert 'no approach needed' in result.lower()
+        mock_navigator.spin.assert_not_called()
+        mock_navigator.driveOnHeading.assert_not_called()
+
+    @patch('nav2_mcp_server.navigation.BasicNavigator')
+    def test_approach_target_drives_without_spin_when_aligned(
+        self, mock_navigator_class: Mock
+    ) -> None:
+        """Test that approach_target skips the spin when bearing is small.
+
+        A target at (1.85, 0.0) with a 0.85 m standoff requires a
+        ~1.0 m forward drive but no spin (bearing is zero). The spin
+        action must not be invoked.
+        """
+        mock_navigator = Mock()
+        mock_navigator.getResult.return_value = TaskResult.SUCCEEDED
+        mock_navigator_class.return_value = mock_navigator
+
+        nav_manager = NavigationManager()
+        context_manager = MCPContextManager()
+
+        result = nav_manager.approach_target(
+            target_x_base=1.85,
+            target_y_base=0.0,
+            standoff_m=0.85,
+            speed=0.2,
+            context_manager=context_manager,
+        )
+
+        assert 'approached target' in result.lower()
+        mock_navigator.spin.assert_not_called()
+        mock_navigator.driveOnHeading.assert_called_once()
+
+    @patch('nav2_mcp_server.navigation.BasicNavigator')
+    def test_approach_target_spins_then_drives_when_off_axis(
+        self, mock_navigator_class: Mock
+    ) -> None:
+        """Test that approach_target spins to face target before driving.
+
+        A target offset sideways yields a bearing well above the
+        8-degree threshold, so the robot must spin first and then
+        drive. Verifies the call order and that both actions ran.
+        """
+        mock_navigator = Mock()
+        mock_navigator.getResult.return_value = TaskResult.SUCCEEDED
+        mock_navigator_class.return_value = mock_navigator
+
+        nav_manager = NavigationManager()
+        context_manager = MCPContextManager()
+
+        result = nav_manager.approach_target(
+            target_x_base=1.5,
+            target_y_base=1.5,
+            standoff_m=0.85,
+            speed=0.2,
+            context_manager=context_manager,
+        )
+
+        assert 'approached target' in result.lower()
+        mock_navigator.spin.assert_called_once()
+        mock_navigator.driveOnHeading.assert_called_once()
+
+
+class TestEnsureActionServer:
+    """Tests for the _ensure_action_server fail-fast pre-flight check."""
+
+    @patch('nav2_mcp_server.navigation.BasicNavigator')
+    def test_ensure_action_server_passes_when_available(
+        self, mock_navigator_class: Mock
+    ) -> None:
+        """Test that _ensure_action_server returns silently when ready.
+
+        The helper must not raise when the action client reports the
+        server as available within the timeout.
+        """
+        mock_navigator = Mock()
+        mock_navigator_class.return_value = mock_navigator
+
+        client = Mock()
+        client.wait_for_server.return_value = True
+
+        nav_manager = NavigationManager()
+        nav_manager._ensure_action_server(client, '/some_action', timeout=1.0)
+
+        client.wait_for_server.assert_called_once_with(timeout_sec=1.0)
+
+    @patch('nav2_mcp_server.navigation.BasicNavigator')
+    def test_ensure_action_server_raises_when_unavailable(
+        self, mock_navigator_class: Mock
+    ) -> None:
+        """Test that _ensure_action_server fails fast when not ready.
+
+        When wait_for_server returns False (server not advertised
+        within the budget), the helper must raise a NavigationError
+        with NAV2_NOT_ACTIVE so the caller surfaces an actionable
+        failure instead of hanging.
+        """
+        from nav2_mcp_server.exceptions import NavigationErrorCode
+        mock_navigator = Mock()
+        mock_navigator_class.return_value = mock_navigator
+
+        client = Mock()
+        client.wait_for_server.return_value = False
+
+        nav_manager = NavigationManager()
+        with pytest.raises(NavigationError) as exc_info:
+            nav_manager._ensure_action_server(
+                client, '/missing_action', timeout=0.5
+            )
+
+        assert exc_info.value.error_code == (
+            NavigationErrorCode.NAV2_NOT_ACTIVE
+        )
+        client.wait_for_server.assert_called_once_with(timeout_sec=0.5)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -230,6 +230,132 @@ class TestBackupRobot:
             mock_navigation_manager.backup_robot.assert_called_once()
 
 
+class TestDriveOnHeading:
+    """Tests for drive_on_heading tool."""
+
+    @patch('nav2_mcp_server.tools.get_transform_manager')
+    @patch('nav2_mcp_server.tools.get_navigation_manager')
+    async def test_drive_on_heading_success(
+        self,
+        mock_get_nav_manager: Mock,
+        mock_get_tf_manager: Mock,
+        test_server: FastMCP,
+        mock_navigation_manager: Mock
+    ) -> None:
+        """Test successful forward drive via drive_on_heading tool."""
+        mock_get_nav_manager.return_value = mock_navigation_manager
+        async with Client(test_server) as client:
+            result = await client.call_tool(
+                'drive_on_heading',
+                {
+                    'distance': 0.5,
+                    'speed': 0.2
+                }
+            )
+
+            assert result.content
+            mock_navigation_manager.drive_on_heading.assert_called_once()
+
+    @patch('nav2_mcp_server.tools.get_config')
+    @patch('nav2_mcp_server.tools.get_transform_manager')
+    @patch('nav2_mcp_server.tools.get_navigation_manager')
+    async def test_drive_on_heading_default_speed(
+        self,
+        mock_get_nav_manager: Mock,
+        mock_get_tf_manager: Mock,
+        mock_get_config: Mock,
+        test_server: FastMCP,
+        mock_navigation_manager: Mock
+    ) -> None:
+        """Test drive_on_heading falls back to config speed when omitted.
+
+        Verifies that omitting the speed argument causes the tool to
+        substitute config.navigation.default_backup_speed (motion
+        limits are direction-agnostic, so backup-speed bounds apply).
+        """
+        mock_get_nav_manager.return_value = mock_navigation_manager
+        config_obj = Mock()
+        config_obj.navigation.default_backup_speed = 0.25
+        mock_get_config.return_value = config_obj
+
+        async with Client(test_server) as client:
+            result = await client.call_tool(
+                'drive_on_heading',
+                {
+                    'distance': 0.5
+                    # speed omitted, should use default
+                }
+            )
+
+            assert result.content
+            mock_navigation_manager.drive_on_heading.assert_called_once()
+
+
+class TestApproachTarget:
+    """Tests for approach_target tool."""
+
+    @patch('nav2_mcp_server.tools.get_transform_manager')
+    @patch('nav2_mcp_server.tools.get_navigation_manager')
+    async def test_approach_target_success(
+        self,
+        mock_get_nav_manager: Mock,
+        mock_get_tf_manager: Mock,
+        test_server: FastMCP,
+        mock_navigation_manager: Mock
+    ) -> None:
+        """Test successful approach via approach_target tool."""
+        mock_get_nav_manager.return_value = mock_navigation_manager
+        async with Client(test_server) as client:
+            result = await client.call_tool(
+                'approach_target',
+                {
+                    'target_x_base': 1.5,
+                    'target_y_base': 0.0,
+                    'standoff_m': 0.85,
+                    'speed': 0.2
+                }
+            )
+
+            assert result.content
+            mock_navigation_manager.approach_target.assert_called_once()
+
+    @patch('nav2_mcp_server.tools.get_config')
+    @patch('nav2_mcp_server.tools.get_transform_manager')
+    @patch('nav2_mcp_server.tools.get_navigation_manager')
+    async def test_approach_target_default_speed(
+        self,
+        mock_get_nav_manager: Mock,
+        mock_get_tf_manager: Mock,
+        mock_get_config: Mock,
+        test_server: FastMCP,
+        mock_navigation_manager: Mock
+    ) -> None:
+        """Test approach_target falls back to config speed when omitted.
+
+        Verifies that omitting the speed argument causes the tool to
+        substitute config.navigation.default_backup_speed for the
+        forward-drive leg of the approach.
+        """
+        mock_get_nav_manager.return_value = mock_navigation_manager
+        config_obj = Mock()
+        config_obj.navigation.default_backup_speed = 0.25
+        mock_get_config.return_value = config_obj
+
+        async with Client(test_server) as client:
+            result = await client.call_tool(
+                'approach_target',
+                {
+                    'target_x_base': 1.5,
+                    'target_y_base': 0.0,
+                    'standoff_m': 0.85
+                    # speed omitted, should use default
+                }
+            )
+
+            assert result.content
+            mock_navigation_manager.approach_target.assert_called_once()
+
+
 class TestDockRobot:
     """Tests for dock_robot tool."""
 


### PR DESCRIPTION
## Summary

Two new Nav2 MCP primitives — `drive_on_heading` and `approach_target`, plus a precondition fix that prevents `BasicNavigator` from hanging when nav2 action servers are not yet active.

## Background

Short-range positioning is awkward to express through `navigate_to_pose`. The global planner refuses goals that fall inside the costmap inflation (close to walls, near obstacles), and even when a goal is accepted, the planner detours through inflated regions instead of just driving straight. For mobile-manipulator workflows that need to creep up to a perception target before grasping, a direct heading-following primitive is more appropriate.

`drive_on_heading` wraps the existing `BasicNavigator.driveOnHeading` action behind an MCP tool. `approach_target` composes it with `spin_robot` to position the robot at a configurable standoff distance from a target whose XY is known in `base_footprint`.

While integrating these, a separate fail-fast guard was added: `BasicNavigator`'s action client methods call `wait_for_server()` with no timeout, so missing or inactive action servers cause indefinite hangs. The first commit in this PR addresses that.

## Changes

### `fix: pre-flight wait_for_server check on Nav2 action clients`

Adds a private `_ensure_action_server(client, action_name, timeout=5.0)` helper that runs `wait_for_server(timeout_sec=timeout)` before each goal-sending call. On miss, raises `NAV2_NOT_ACTIVE` with an actionable message instead of hanging client-side for 90–180 s. Applied to `navigate_to_pose`, `follow_waypoints`, `spin_robot`, `backup_robot`, `dock_robot`, and `undock_robot`. The new primitives in this PR also use it.

### `feat: drive_on_heading primitive`

Wraps `BasicNavigator.driveOnHeading` as the `drive_on_heading` MCP tool. Reuses the existing backup distance and speed validation ranges since the motion limits are direction-agnostic.

### `feat: approach_target primitive - spin-and-drive to base-frame target at standoff`

Drives the robot to a configurable standoff distance from a target whose XY is given in `base_footprint`. Spins to face the target if the bearing is significant (~8° threshold), then delegates to `drive_on_heading` for the forward leg. Returns immediately if already within `standoff + 0.10 m`.

The implementation composes the two underlying manager methods (`spin_robot`, `drive_on_heading`) rather than calling `BasicNavigator` directly, so range validation, action-server checks, and result handling stay centralized.

## Notes

The bundled fix (`_ensure_action_server`) is included here because the two new primitives depend on it. Splitting it into a standalone PR is straightforward if you prefer then let me know :)
